### PR TITLE
removed methods from configure services

### DIFF
--- a/MediaBay/src/MediaBay/Controllers/ProductController.cs
+++ b/MediaBay/src/MediaBay/Controllers/ProductController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Cors;
 using MediaBay.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Cors;
 
 // For more information on enabling Web API for empty projects, 
 // visit http://go.microsoft.com/fwlink/?LinkID=397860
@@ -73,6 +74,7 @@ namespace MediaBay.Controllers
         //}
 
         // POST api/product
+        [EnableCors("AllowNewDevelopmentEnvironment")]
         [HttpPost]
         public IActionResult Post([FromBody]Product product)
         {

--- a/MediaBay/src/MediaBay/Startup.cs
+++ b/MediaBay/src/MediaBay/Startup.cs
@@ -42,7 +42,7 @@ namespace MediaBay
                      builder => builder
                         .AllowAnyOrigin() //allows from anything(including virtual box)
                         .AllowAnyMethod()
-                        .AllowAnyHeader().WithMethods("DELETE, PUT, POST, GET, OPTIONS"));
+                        .AllowAnyHeader());
             });
         }
 
@@ -50,8 +50,9 @@ namespace MediaBay
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             // allows me to build the project so that I can view it in localhost
-            app.UseCors(builder =>
-            builder.WithOrigins("http://example.com"));
+            //app.UseCors(builder =>
+            //builder.WithOrigins("http://example.com"));
+            app.UseCors("AllowAll");
 
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();

--- a/MediaBay/src/MediaBay/project.json
+++ b/MediaBay/src/MediaBay/project.json
@@ -1,20 +1,20 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702",
-      "type": "platform"
-    },
     "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-rc2-final",
+    "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview1-final",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-rc2-final",
-    "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview1-final"
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0-rc2-3002702",
+      "type": "platform"
+    }
   },
 
   "tools": {


### PR DESCRIPTION
Inside of the ConfigureServices method of the Startup.cs file there was a conflict with the builder that allowed all requests, but then also limited requests to only GET, POST, PUT, DELETE methods. So removing this line allowed the front end application to POST a new product. It is an odd problem to solve because none of this was a problem while testing in Postman.
